### PR TITLE
Made multiple bridges/vehicles possible.

### DIFF
--- a/include/imc_tcp_link/imc_handle.h
+++ b/include/imc_tcp_link/imc_handle.h
@@ -23,6 +23,7 @@ private:
 
     std::string sys_name;
     int imc_id;
+	int imc_src;
     std::string bridge_tcp_addr;
     std::string bridge_tcp_port;
     std::string neptus_addr;
@@ -40,7 +41,7 @@ public:
 
     IMCHandle(const std::string& bridge_tcp_addr, const std::string& bridge_tcp_port,
               const std::string& neptus_addr,
-              const std::string& sys_name, int imc_id);
+              const std::string& sys_name, int imc_id, int imc_src);
 
     ~IMCHandle();
 

--- a/include/imc_udp_link/udp_link.h
+++ b/include/imc_udp_link/udp_link.h
@@ -53,12 +53,13 @@ private:
 
     int imc_src = 4;
     int imc_src_ent = 32;
+	int imc_id;
 
 public:
 
     UDPLink(std::function<void (IMC::Message*)> recv_handler,
             const std::string& bridge_addr, const std::string& bridge_port,
-            int imc_src);
+            int imc_id, int imc_src);
 
     ~UDPLink();
 

--- a/launch/bridge.launch
+++ b/launch/bridge.launch
@@ -14,6 +14,7 @@
 
   <!-- 4=imc_ros_bridge, 5=sam, 6=lolo -->
   <arg name="imc_id" default="4"/>
+  <arg name="imc_src" default="$(arg imc_id)"/>
 
   <node pkg="imc_ros_bridge" type="bridge_node" name="$(arg node_name)" output="screen">
     <param name="neptus_addr" value="$(arg neptus_addr)"/>
@@ -21,6 +22,7 @@
     <param name="bridge_port" value="$(arg bridge_port)" type="str"/>
     <param name="system_name" value="$(arg imc_system_name)"/>
     <param name="imc_id" value="$(arg imc_id)"/>
+    <param name="imc_src" value="$(arg imc_src)"/>
   </node>
 
 </launch>

--- a/launch/bridge_sam.launch
+++ b/launch/bridge_sam.launch
@@ -17,6 +17,8 @@
 
   <!-- 4=imc_ros_bridge, 5=sam, 6=lolo -->
   <arg name="imc_id" default="5"/>
+  <arg name="imc_src" default="$(arg imc_id)"/>
+
 
 
   <include file="$(find imc_ros_bridge)/launch/bridge.launch" 

--- a/src/bridge_node.cpp
+++ b/src/bridge_node.cpp
@@ -51,13 +51,15 @@ int main(int argc, char** argv)
     std::string bridge_tcp_port;
     std::string sys_name;
     int imc_id;
+	int imc_src;
     ros::param::param<std::string>("~neptus_addr", neptus_addr, "127.0.0.1");
     ros::param::param<std::string>("~bridge_addr", bridge_tcp_addr, "127.0.0.1");
     ros::param::param<std::string>("~bridge_port", bridge_tcp_port, "6002");
     ros::param::param<std::string>("~system_name", sys_name, "imc_ros_bridge");
     ros::param::param<int>("~imc_id", imc_id, 30);
+	ros::param::param<int>("~imc_src", imc_src, 5);
 
-    IMCHandle imc_handle(bridge_tcp_addr, bridge_tcp_port, neptus_addr, sys_name, imc_id);
+    IMCHandle imc_handle(bridge_tcp_addr, bridge_tcp_port, neptus_addr, sys_name, imc_id, imc_src);
 
     ros_to_imc::BridgeServer<std_msgs::Empty, IMC::Heartbeat> heartbeat_server(ros_node, imc_handle, "heartbeat");
     ros_to_imc::BridgeServer<sensor_msgs::NavSatFix, IMC::GpsFix> gpsfix_server(ros_node, imc_handle, "gps_fix");

--- a/src/imc_handle.cpp
+++ b/src/imc_handle.cpp
@@ -25,14 +25,17 @@ void try_callback(const IMC::Message* imc_msg)
 		std::cout << "Got callback with id: " << imc_msg->getId() << std::endl;
 }
 
-IMCHandle::IMCHandle(const std::string& bridge_tcp_addr, const std::string& bridge_tcp_port,
+IMCHandle::IMCHandle(const std::string& bridge_tcp_addr, 
+					 const std::string& bridge_tcp_port,
                      const std::string& neptus_addr,
-                     const std::string& sys_name, int imc_id)
+                     const std::string& sys_name, 
+					 int imc_id, 
+					 int imc_src)
     : udp_link(std::bind(&IMCHandle::tcp_callback, this, std::placeholders::_1),
-               bridge_tcp_addr, bridge_tcp_port, imc_id),
+               bridge_tcp_addr, bridge_tcp_port, imc_id, imc_src),
       neptus_addr(neptus_addr),
       bridge_tcp_addr(bridge_tcp_addr), bridge_tcp_port(bridge_tcp_port),
-      sys_name(sys_name), imc_id(imc_id)
+      sys_name(sys_name), imc_id(imc_id), imc_src(imc_src)
 {
     lat = 0.0;
     announce();

--- a/src/udp_link.cpp
+++ b/src/udp_link.cpp
@@ -25,8 +25,8 @@ std::ofstream myfile;
 using namespace std;
 
 UDPLink::UDPLink(std::function<void (IMC::Message*)> recv_handler,
-        const std::string& bridge_addr, const std::string& bridge_port, int imc_src)
-    : recv_handler_(recv_handler), bridge_addr(bridge_addr), bridge_port(bridge_port), imc_src(imc_src)
+        const std::string& bridge_addr, const std::string& bridge_port, int imc_id, int imc_src)
+    : recv_handler_(recv_handler), bridge_addr(bridge_addr), bridge_port(bridge_port), imc_id(imc_id), imc_src(imc_src)
 {
     socket.open(udp::v4());
     socket.set_option(udp::socket::reuse_address(true));
@@ -60,7 +60,7 @@ void handler(const boost::system::error_code& error, size_t bytes_transferred)
 void UDPLink::publish(IMC::Message& msg, const string& addr)
 {
     msg.setSource(imc_src);
-    msg.setSourceEntity(imc_src);
+    msg.setSourceEntity(imc_id);
     msg.setDestination(0);
     msg.setTimeStamp(ros::Time::now().toSec());
 
@@ -81,7 +81,7 @@ void UDPLink::publish(IMC::Message& msg, const string& addr)
 void UDPLink::publish_multicast(IMC::Message& msg, const string& multicast_addr)
 {
     msg.setSource(imc_src);
-    msg.setSourceEntity(imc_src);
+    msg.setSourceEntity(imc_id);
     msg.setDestination(0);
     msg.setTimeStamp(ros::Time::now().toSec());
 


### PR DESCRIPTION
Added new imc_src argument to udp_link. imc messages have src_ent to separate different vehicles of the same type and id. imc_src is passed on to src_ent of every message